### PR TITLE
draft 03 analysis notebook

### DIFF
--- a/notebooks/03 Data Analysis with Visual Analytics.ipynb
+++ b/notebooks/03 Data Analysis with Visual Analytics.ipynb
@@ -26,10 +26,56 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cudf\n",
+    "import cugraph\n",
+    "import cupy\n",
+    "import cuspatial\n",
+    "\n",
+    "import pandas as pd\n",
+    "\n",
+    "import hvplot.cudf\n",
+    "import hvplot.pandas"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Load Cleaned Data / Check"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "DATA_DIR = Path(\"./data\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = cudf.read_csv(DATA_DIR / \"data.csv\", parse_dates=('starttime', 'stoptime'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stations = pd.read_csv(DATA_DIR / \"stations.csv\")"
    ]
   },
   {
@@ -44,25 +90,351 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Intro to cuML / cuSpatial Other Libraries\n",
-    "Overview of RAPIDS libraies and uses"
+    "## Intro to cuGraph / cuSpatial / cupy\n",
+    "\n",
+    "We will analyze the data using some RAPIDS tools:\n",
+    "\n",
+    "* [cuGraph](https://docs.rapids.ai/api/cugraph/stable/) is a collection of GPU accelerated graph algorithms that process data found in GPU DataFrames. We can use to compute pagerank or degree measure on the trip graph. \n",
+    "\n",
+    "* [cuSpatial](https://docs.rapids.ai/api/cuspatial/nightly/) is a collection of GPU accelerated algorithms for computing geo-spatial measures. We can use to to compute trips with given bounding regions."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Iteration 1\n",
-    "cuxfilter results, tweak parameters"
+    "## Spatial\n",
+    "\n",
+    "Let's take a look at some spatial measures and see if there are any interesting features.\n",
+    "\n",
+    "We might start with the first station, and see what the min/max trip length from it are."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r0 = df.iloc[0]\n",
+    "origin_lon, origin_lat = r0[\"longitude_start\"], r0[\"latitude_start\"]"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Iteration 2\n",
-    "cxfilter results, tweak parameters"
+    "The cuSpatial function `lonlat_to_cartesian` will let us quicly compute the x/y distances for every ending trip location:"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dist = cuspatial.lonlat_to_cartesian(origin_lon[0], origin_lat[0], df[\"longitude_end\"], df[\"latitude_end\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "CuPy functions can compute derived values on these GPU dataframes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cupy.sqrt(cupy.max(dist.x**2 + dist.y**2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "What if we want to compute this max/min trip interval for every station as a starting point?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from_intervals = []\n",
+    "\n",
+    "for idx, row in stations.iterrows():\n",
+    "    station_id, origin_lon, origin_lat = int(row[\"station_id\"]), row[\"lon\"], row[\"lat\"]\n",
+    "    dist = cuspatial.lonlat_to_cartesian(origin_lon, origin_lat, df[\"longitude_end\"], df[\"latitude_end\"])\n",
+    "    from_intervals.append((station_id, float(cupy.sqrt(cupy.max(dist.x**2 + dist.y**2)))))\n",
+    "\n",
+    "from_intervals = pd.DataFrame(from_intervals, columns=[\"station_id\", \"dist\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from_longest = from_intervals.nlargest(25, \"dist\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from_longest_loc = stations[stations.station_id.isin(from_longest.station_id)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "from_longest_loc.hvplot.points(x='lon', y='lat', size=300, geo=True, tiles=\"OSM\").opts(width=800, height=800)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Pagerank\n",
+    "\n",
+    "We will use the `cugraph.pagerank` function to see if there are patterns for the \"most popular\" stations. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df[\"weekday\"] = df['starttime'].dt.weekday"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Single hour \n",
+    "\n",
+    "Let's see what it looks like to compute page range for a single hour of the day, e.g. 5PM. First subset the data to only look at data for trips starting at that hour:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "d17 = df[df[\"hour\"]==17]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next group by (from_station_id, to_station_id) and then take the group size to get all the unique indivual routes between stations that hour, and also the number of trips that took each of those routes:/"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g17 = df.groupby(by=[\"from_station_id\", \"to_station_id\"])\n",
+    "routes17 = g17.size().reset_index()\n",
+    "routes17.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we can create a `cugraph.Graph` "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "G = cugraph.Graph()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "G.from_cudf_edgelist(d17, source='from_station_id', destination='to_station_id')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "d17_page = cugraph.pagerank(G)\n",
+    "d17_page.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "d17_top = d17_page.nlargest(10, \"pagerank\").to_pandas()\n",
+    "d17_top.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "d17_page_locs = stations[stations.station_id.isin(d17_top.vertex)]\n",
+    "d17_page_locs.hvplot.points(x='lon', y='lat', size=300, geo=True, tiles=\"OSM\").opts(width=800, height=800)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's repeat the same  process and see the highest ranked stations at noon"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "d8 = df[df[\"hour\"]==12]\n",
+    "g8 = df.groupby(by=[\"from_station_id\", \"to_station_id\"])\n",
+    "routes17 = g8.size().reset_index()\n",
+    "\n",
+    "G = cugraph.Graph()\n",
+    "G.from_cudf_edgelist(d8, source='from_station_id', destination='to_station_id')\n",
+    "d8_page = cugraph.pagerank(G)\n",
+    "d8_page.head()\n",
+    "\n",
+    "d8_top = d8_page.nlargest(10, \"pagerank\").to_pandas()\n",
+    "\n",
+    "d8_page_locs = stations[stations.station_id.isin(d8_top.vertex)]\n",
+    "d8_page_locs.hvplot.points(x='lon', y='lat', size=300, geo=True, tiles=\"OSM\").opts(width=800, height=800)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's look at how stations rank week on weekdays vs weekends. The code below computes the pagerank broken out by individual day of the week."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = {}\n",
+    "for w in range(7):\n",
+    "    dfw = df[df[\"weekday\"]==w]\n",
+    "    G = cugraph.Graph()\n",
+    "    G.from_cudf_edgelist(dfw, source='from_station_id', destination='to_station_id')\n",
+    "    df_page = cugraph.pagerank(G).nlargest(20, \"pagerank\")\n",
+    "    results[w] = set(df_page.to_pandas()[\"vertex\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's find out what stations were highest ranked among all weekdays and weekend days"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "weekday = set.intersection(*[results[i] for i in range(5)])\n",
+    "weekend = set.intersection(results[5], results[6])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "weekend"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "weekday"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally we can plot these quickly using `hvplot`. Let's add a column to denote weekday/weekend so that we can group by that"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r1 = stations[stations.station_id.isin(weekend)]\n",
+    "r1 = r1.assign(type=\"Weekend\")\n",
+    "\n",
+    "r2 = stations[stations.station_id.isin(weekday)]\n",
+    "r2 = r2.assign(type=\"Weekday\")\n",
+    "\n",
+    "result = pd.concat([r1, r2])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result.hvplot.points(x='lon', y='lat', by='type', alpha=0.5, size=485, geo=True, tiles=\"OSM\").opts(width=800, height=800)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -96,7 +468,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
cc @exactlyallan 

This notebook uses cuspatial (and a bit cupy) to see what stations had the longest trips. It also uses page rank rank trips a 5pm and noon, and also to see rankings split by weekday/weekend. I didn't yet further break out by time because that seems to get in to a fair amount of data munging that isn't really directly related to rapids APIs and where it is related, is repetitive of the previous examples. 

note: also assumes the `stations.csv` from 01 notebook has been created