### PR TITLE
Fix image rendering in the 4th notebook

### DIFF
--- a/notebooks/04 Explanatory Data Visualization.ipynb
+++ b/notebooks/04 Explanatory Data Visualization.ipynb
@@ -54,8 +54,8 @@
    "metadata": {},
    "source": [
     "### A Note About Sketching and Design Iterations\n",
-    "<img src=\" https://raw.githubusercontent.com/jupytercon/2020-exactlyallan/master/images/dashboard-sketch-ideas.jpg\" />\n",
-    "<img src=\" https://raw.githubusercontent.com/jupytercon/2020-exactlyallan/master/images/plotly_dashboard_sketch.jpg\" />\n",
+    "<img src=\"https://raw.githubusercontent.com/jupytercon/2020-exactlyallan/master/images/dashboard-sketch-ideas.jpg\" />\n",
+    "<img src=\"https://raw.githubusercontent.com/jupytercon/2020-exactlyallan/master/images/plotly_dashboard_sketch.jpg\" />\n",
     "\n",
     "A well designed visualization owes as much to iteration as it does to skill (though experience helps). The more iterations, generally the better the viz. However, the mental overhead of our technical tools often get in the way of our thought process.\n",
     "\n",


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/591645/94926257-c88f5280-04c0-11eb-8817-1c429a58af5e.png)

After:

![image](https://user-images.githubusercontent.com/591645/94926269-cf1dca00-04c0-11eb-9b20-6364fee5f18a.png)
